### PR TITLE
Solves Issue #26 using uri filenames.

### DIFF
--- a/pysradb/basedb.py
+++ b/pysradb/basedb.py
@@ -2,6 +2,7 @@ import sqlite3
 import sys
 
 import pandas as pd
+import os
 
 from .utils import _extract_first_field
 
@@ -24,7 +25,9 @@ class BASEdb(object):
 
     def open(self):
         """Open sqlite connection."""
-        self.db = sqlite3.connect(self.sqlite_file)
+        sqlite_file_path = os.getcwd()
+        check_file = "{}/{}".format(sqlite_file_path, self.sqlite_file)  # str(sqlite_file_path)+"/"+str(self.sqlite_file)
+        self.db = sqlite3.connect('file:{}?mode=rw'.format(check_file), uri=True)
         self.db.text_factory = str
 
     def close(self):

--- a/pysradb/sradb.py
+++ b/pysradb/sradb.py
@@ -177,7 +177,14 @@ class SRAdb(BASEdb):
 
 
         """
-        super(SRAdb, self).__init__(sqlite_file)
+        try:
+            super(SRAdb, self).__init__(sqlite_file)
+        except:
+            print(
+            "{} not a valid SRAmetadb.sqlite file.\n".format(sqlite_file)
+            + "Please download one using `pysradb metadb`."
+            )
+            sys.exit(1)
         _verify_srametadb(sqlite_file)
         self._db_type = "SRA"
         self.valid_in_acc_type = [


### PR DESCRIPTION
Line 27 in basedb.py was causing this issue by creating a new file if it didn't exist and did not check if the file existed or not thus except block on line 152 in sradb.py was never activated. I changed the argument for sqlite3.connect() command using uri syntax which allows customizing the course of action if a file already exists and if doesn't. Changed it to throw an error if file is not found which is caught at line 182 in sradb.py. 
Use case 
```
from pysradb import SRAdb
db = SRAdb('this_shouldnt_exist')
df = db.sra_metadata('SRP098789')
df.head() 
```
It throws an error and returns 
```
(pysradb) saad@DaasDaham:~/Desktop/pysradb$ python sample.py
this_shouldnt_exist not a valid SRAmetadb.sqlite file.
Please download one using `pysradb metadb`.
```