### PR TITLE
fix collisions of ena_urls in merge

### DIFF
--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -542,8 +542,14 @@ class SRAweb(SRAdb):
         metadata_df = metadata_df[metadata_df.columns.dropna()]
         metadata_df = metadata_df.drop_duplicates()
         metadata_df = metadata_df.replace(r"^\s*$", np.nan, regex=True)
-        ena_cols = ["ena_fastq_http", "ena_fastq_http_1", "ena_fastq_http_2",
-                    "ena_fastq_ftp", "ena_fastq_ftp_1", "ena_fastq_ftp_2"]
+        ena_cols = [
+            "ena_fastq_http",
+            "ena_fastq_http_1",
+            "ena_fastq_http_2",
+            "ena_fastq_ftp",
+            "ena_fastq_ftp_1",
+            "ena_fastq_ftp_2",
+        ]
         metadata_df[ena_cols] = np.nan
 
         metadata_df = metadata_df.set_index("run_accession")
@@ -551,9 +557,7 @@ class SRAweb(SRAdb):
             ena_results = self.fetch_ena_fastq(srp)
             if ena_results.shape[0]:
                 ena_results = ena_results.set_index("run_accession")
-                metadata_df.update(
-                    ena_results
-                )
+                metadata_df.update(ena_results)
         metadata_df = metadata_df.reset_index()
         metadata_df = metadata_df.fillna("N/A")
         return metadata_df

--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -546,11 +546,11 @@ class SRAweb(SRAdb):
                     "ena_fastq_ftp", "ena_fastq_ftp_1", "ena_fastq_ftp_2"]
         metadata_df[ena_cols] = np.nan
 
-        metadata_df.set_index("run_accession")
+        metadata_df = metadata_df.set_index("run_accession")
         for srp in metadata_df.study_accession.unique():
             ena_results = self.fetch_ena_fastq(srp)
             if ena_results.shape[0]:
-                ena_results.set_index("run_accession")
+                ena_results = ena_results.set_index("run_accession")
                 metadata_df.update(
                     ena_results
                 )

--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -542,12 +542,19 @@ class SRAweb(SRAdb):
         metadata_df = metadata_df[metadata_df.columns.dropna()]
         metadata_df = metadata_df.drop_duplicates()
         metadata_df = metadata_df.replace(r"^\s*$", np.nan, regex=True)
+        ena_cols = ["ena_fastq_http", "ena_fastq_http_1", "ena_fastq_http_2",
+                    "ena_fastq_ftp", "ena_fastq_ftp_1", "ena_fastq_ftp_2"]
+        metadata_df[ena_cols] = np.nan
+
+        metadata_df.set_index("run_accession")
         for srp in metadata_df.study_accession.unique():
             ena_results = self.fetch_ena_fastq(srp)
             if ena_results.shape[0]:
-                metadata_df = metadata_df.merge(
-                    ena_results, on="run_accession", how="left"
+                ena_results.set_index("run_accession")
+                metadata_df.update(
+                    ena_results
                 )
+        metadata_df = metadata_df.reset_index()
         metadata_df = metadata_df.fillna("N/A")
         return metadata_df
 

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -42,6 +42,15 @@ def test_sra_metadata_multiple_detailed(sraweb_connection):
     df = sraweb_connection.sra_metadata(["SRP002605", "SRP098789"], detailed=True)
     columns = ["treatment time", "library type", "transfection", "time"]
     assert len(set(columns).intersection(set(df.columns))) == 4
+    ftp_cols = [
+        "ena_fastq_http",
+        "ena_fastq_http_1",
+        "ena_fastq_http_2",
+        "ena_fastq_ftp",
+        "ena_fastq_ftp_1",
+        "ena_fastq_ftp_2",
+    ]
+    assert len(set(ftp_cols).intersection(set(df.columns))) == 6
 
 
 def test_tissue_column(sraweb_connection):


### PR DESCRIPTION
When merging from multiple srp's the current approach keeps adding columns with _x and _y to avoid collisions.

I replaced the pandas merge function with update since we actually want to overwrite the nan values.

Related to #56 