### PR TITLE
multithreaded ena loading

### DIFF
--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -4,7 +4,7 @@ import sys
 import time
 import warnings
 from collections import OrderedDict
-from html import unescape
+import concurrent.futures
 from xml.parsers.expat import ExpatError
 
 import numpy as np
@@ -553,11 +553,20 @@ class SRAweb(SRAdb):
         metadata_df[ena_cols] = np.nan
 
         metadata_df = metadata_df.set_index("run_accession")
-        for srp in metadata_df.study_accession.unique():
-            ena_results = self.fetch_ena_fastq(srp)
-            if ena_results.shape[0]:
-                ena_results = ena_results.set_index("run_accession")
-                metadata_df.update(ena_results)
+        # multithreading lookup on ENA, since a lot of time is spent waiting
+        # for its reply
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            # load our function calls into a list of futures
+            futures = [
+                executor.submit(self.fetch_ena_fastq, srp)
+                for srp in metadata_df.study_accession.unique()
+            ]
+            # now proceed synchronously
+            for future in concurrent.futures.as_completed(futures):
+                ena_results = future.result()
+                if ena_results.shape[0]:
+                    ena_results = ena_results.set_index("run_accession")
+                    metadata_df.update(ena_results)
         metadata_df = metadata_df.reset_index()
         metadata_df = metadata_df.fillna("N/A")
         return metadata_df


### PR DESCRIPTION
As mentioned in #61 I thought the "long" duration for my lookups came from unnecessary waits. However the main duration of `pysradb.SRAweb.sra_metadata` is actually spent in waiting for ENA to reply. By doing the requests to ENA in a threadpool we can speed up this process significantly:

```
import pysradb
import time

db = pysradb.SRAweb()
now = time.time()

result = db.sra_metadata(
    ["GSM2837485",
     "GSM2385309",
     "GSM3141725",
     "GSM2385313",
     "GSM3756611",
     "GSM2219686",
     "GSM2811115",
     "DRR138954",
     "GSM2837501",
     "DRR138997",
     "SRR10680309"]
    , detailed=True)


print(result)
print(time.time() - now)
```
This goes from 36.8 to 15.5 seconds. 

It can be sped up even more by increasing the amount of threads in the pool, but I think ENA would not appreciate that.