### PR TITLE
allow namespace

### DIFF
--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -119,7 +119,7 @@ class SRAweb(SRAdb):
                   Parsed xml as dict
         """
         try:
-            json = xmltodict.parse(xml)["root"]
+            json = xmltodict.parse(xml, process_namespaces=True)["root"]
         except ExpatError:
             raise RuntimeError("Unable to parse xml: {}".format(xml))
         return json

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -219,3 +219,8 @@ def test_srx_to_srs(sraweb_connection):
     """Test if srx is converted to srs correctly"""
     df = sraweb_connection.srx_to_srs("SRX663253")
     assert list(df["sample_accession"]) == ["SRS668126"]
+
+
+def test_xmlns_id(sraweb_connection):
+    df = sraweb_connection.sra_metadata(["GSM1013144", "GSM2520660"])
+    assert list(df["library_layout"]) == ["SINGLE"] * 2

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -223,4 +223,4 @@ def test_srx_to_srs(sraweb_connection):
 
 def test_xmlns_id(sraweb_connection):
     df = sraweb_connection.sra_metadata(["GSM1013144", "GSM2520660"])
-    assert list(df["library_layout"]) == ["SINGLE"] * 2
+    assert list(df["library_layout"]) == ["PAIRED", "SINGLE"]


### PR DESCRIPTION
See issue #64. I have practically zero experience with xml parsing, however the xmlns specifies the xml namespace for the document. Simply setting `process_namespace` to `True` seems to resolve the issue for me:
https://github.com/martinblech/xmltodict#namespace-support

```
import pysradb
db = pysradb.SRAweb()
df = db.sra_metadata(["GSM1013144", "GSM2520660"], detailed=True)
print(df)
print(df.library_layout)
```

```
  run_accession study_accession experiment_accession  ... ena_fastq_ftp                                    ena_fastq_ftp_1                                    ena_fastq_ftp_2
0    SRR5310913       SRP101305           SRX2610883  ...           N/A  era-fasp@fasp.sra.ebi.ac.uk:vol1/fastq/SRR531/...  era-fasp@fasp.sra.ebi.ac.uk:vol1/fastq/SRR531/...
1     SRR578686       SRP000941            SRX190781  ...           N/A  era-fasp@fasp.sra.ebi.ac.uk:vol1/fastq/SRR578/...                                                   

[2 rows x 46 columns]
0    PAIRED
1    SINGLE
Name: library_layout, dtype: object
```
