### PR TITLE
Add support for downloading GEO files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 1.0.2 (Unreleased)
 *******************
 * Fixed `gsm-to-gse` failure (`#128 <https://github.com/saketkc/pysradb/pull/128>`_)
+* Added support for downloading data from GEO `pysradb dowload -g <GSE>` (`#129 <https://github.com/saketkc/pysradb/pull/129>`_)
 
 *******************
 1.0.1 (01-10-2021)

--- a/pysradb/cli.py
+++ b/pysradb/cli.py
@@ -133,12 +133,7 @@ def download(
     if geo:
         for geo_x in geo:
             links, root_url = geoweb.get_download_links(geo_x)
-            geoweb.download(
-                links=links,
-                root_url=root_url,
-                gse=geo_x,
-                out_dir=out_dir
-            )
+            geoweb.download(links=links, root_url=root_url, gse=geo_x, out_dir=out_dir)
     sradb.close()
 
 

--- a/pysradb/cli.py
+++ b/pysradb/cli.py
@@ -89,7 +89,7 @@ def metadata(srp_id, assay, desc, detailed, expand, saveto):
 
 ################# download ##########################
 def download(
-    out_dir, srx, srp, skip_confirmation, col="sra_url", use_ascp=False, threads=1
+    out_dir, srx, srp, geo, skip_confirmation, col="sra_url", use_ascp=False, threads=1
 ):
 
     if out_dir is None:
@@ -623,6 +623,7 @@ def parse_args(args=None):
     subparser.add_argument("--out-dir", help="Output directory root")
     subparser.add_argument("--srx", "-x", help="Download only these SRX(s)", nargs="+")
     subparser.add_argument("--srp", "-p", help="SRP ID", nargs="+")
+    subparser.add_argument("--geo", "-g", help="GEO ID", nargs="+")
     subparser.add_argument(
         "--skip-confirmation", "-y", action="store_true", help="Skip confirmation"
     )
@@ -1198,6 +1199,7 @@ def parse_args(args=None):
             args.out_dir,
             args.srx,
             args.srp,
+            args.geo,
             args.skip_confirmation,
             args.col,
             args.use_ascp,

--- a/pysradb/geoweb.py
+++ b/pysradb/geoweb.py
@@ -75,14 +75,13 @@ class GEOweb(GEOdb):
 
         # store output in a separate directory
         out_dir = os.path.join(out_dir, gse)
-        if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+        os.makedirs(out_dir, exist_ok=True)
 
         # Display files to be downloaded
-        print("\nThe following files will be downloaded, if not already present: \n")
+        print("\nThe following files will be downloaded: \n")
         for link in links:
             print(link)
-
+        print(os.linesep)
         # Check if we can access list of files in the tar file
         tar_list = [i for i in links if ".tar" in i]
         if "filelist.txt" in links:

--- a/pysradb/geoweb.py
+++ b/pysradb/geoweb.py
@@ -17,10 +17,10 @@ PY3 = True
 if sys.version_info[0] < 3:
     PY3 = False
 
+
 class GEOweb(GEOdb):
     def __init__(self):
-        """Initialize GEOweb without any database.
-        """
+        """Initialize GEOweb without any database."""
 
     def get_download_links(self, gse):
         """Obtain all links from the GEO FTP page.
@@ -40,12 +40,12 @@ class GEOweb(GEOdb):
         link_objects = html.fromstring(requests.get(url).content).xpath("//a")
         links = [i.attrib["href"] for i in link_objects]
 
-        # Check if returned results are a valid page - a link to the 
+        # Check if returned results are a valid page - a link to the
         # home page only exists where the GSE ID dow not exist
         if "/" in links:
             raise KeyError(f"The provided GEO ID {gse} does not exist.")
 
-        # The list of links for a valid GSE ID also contains a link to 
+        # The list of links for a valid GSE ID also contains a link to
         # the parent directory - we do not want that
         links = [i for i in links if "geo/series/" not in i]
 
@@ -54,13 +54,7 @@ class GEOweb(GEOdb):
 
         return links, url
 
-    def download(
-        self,
-        links=None,
-        root_url=None,
-        gse=None,
-        out_dir=None
-    ):
+    def download(self, links=None, root_url=None, gse=None, out_dir=None):
         """Download GEO files.
 
         Parameters
@@ -79,7 +73,7 @@ class GEOweb(GEOdb):
 
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
-        
+
         # Display files to be downloaded
         print("\nThe following files will be downloaded, if not already present: \n")
         for link in links:
@@ -90,7 +84,9 @@ class GEOweb(GEOdb):
         if "filelist.txt" in links:
             tar_file = tar_list[0]
             print(f"\nThe tar file {tar_file} contains the following files:\n")
-            file_list_contents = requests.get(root_url+"filelist.txt").content.decode("utf-8")
+            file_list_contents = requests.get(root_url + "filelist.txt").content.decode(
+                "utf-8"
+            )
             print(file_list_contents)
 
         # Download files
@@ -98,6 +94,8 @@ class GEOweb(GEOdb):
             # add a prefix to distinguish filelist.txt from different downloads
             prefix = ""
             if link == "filelist.txt":
-                prefix = gse+"_"
-            geo_path = os.path.join(out_dir, prefix+link)
-            download_file(root_url.lstrip("https://")+link, geo_path, show_progress=True)
+                prefix = gse + "_"
+            geo_path = os.path.join(out_dir, prefix + link)
+            download_file(
+                root_url.lstrip("https://") + link, geo_path, show_progress=True
+            )

--- a/pysradb/geoweb.py
+++ b/pysradb/geoweb.py
@@ -67,6 +67,10 @@ class GEOweb(GEOdb):
         ----------
         links: list
                List of all links valid downloadable present for a GEO ID
+        root_url: string
+                  url for root directory for a GEO ID
+        gse: string
+             GEO ID
         out_dir: string
                  Directory location for download
         """

--- a/pysradb/geoweb.py
+++ b/pysradb/geoweb.py
@@ -35,7 +35,7 @@ class GEOweb(GEOdb):
         links: list
                List of all valid downloadable links present for a GEO ID
         """
-        prefix = gse[:6]
+        prefix = gse[:-3]
         url = f"https://ftp.ncbi.nlm.nih.gov/geo/series/{prefix}nnn/{gse}/suppl/"
         link_objects = html.fromstring(requests.get(url).content).xpath("//a")
         links = [i.attrib["href"] for i in link_objects]

--- a/pysradb/geoweb.py
+++ b/pysradb/geoweb.py
@@ -54,7 +54,7 @@ class GEOweb(GEOdb):
 
         return links, url
 
-    def download(self, links=None, root_url=None, gse=None, out_dir=None):
+    def download(self, links, root_url, gse, verbose=False, out_dir=None):
         """Download GEO files.
 
         Parameters
@@ -65,12 +65,16 @@ class GEOweb(GEOdb):
                   url for root directory for a GEO ID
         gse: string
              GEO ID
+        verbose: bool
+                 Print file list
         out_dir: string
                  Directory location for download
         """
         if out_dir is None:
             out_dir = os.path.join(os.getcwd(), "pysradb_downloads")
 
+        # store output in a separate directory
+        out_dir = os.path.join(out_dir, gse)
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
 
@@ -83,11 +87,12 @@ class GEOweb(GEOdb):
         tar_list = [i for i in links if ".tar" in i]
         if "filelist.txt" in links:
             tar_file = tar_list[0]
-            print(f"\nThe tar file {tar_file} contains the following files:\n")
-            file_list_contents = requests.get(root_url + "filelist.txt").content.decode(
-                "utf-8"
-            )
-            print(file_list_contents)
+            if verbose:
+                print(f"\nThe tar file {tar_file} contains the following files:\n")
+                file_list_contents = requests.get(
+                    root_url + "filelist.txt"
+                ).content.decode("utf-8")
+                print(file_list_contents)
 
         # Download files
         for link in links:

--- a/pysradb/geoweb.py
+++ b/pysradb/geoweb.py
@@ -1,0 +1,99 @@
+"""Utilities to interact with GEO online"""
+
+import gzip
+import os
+import re
+import requests
+import sys
+from lxml import html
+
+from .download import download_file
+from .geodb import GEOdb
+from .utils import _get_url
+from .utils import copyfileobj
+from .utils import get_gzip_uncompressed_size
+
+PY3 = True
+if sys.version_info[0] < 3:
+    PY3 = False
+
+class GEOweb(GEOdb):
+    def __init__(self):
+        """Initialize GEOweb without any database.
+        """
+
+    def get_download_links(self, gse):
+        """Obtain all links from the GEO FTP page.
+
+        Parameters
+        ----------
+        gse: string
+             GSE ID
+
+        Returns
+        -------
+        links: list
+               List of all valid downloadable links present for a GEO ID
+        """
+        prefix = gse[:6]
+        url = f"https://ftp.ncbi.nlm.nih.gov/geo/series/{prefix}nnn/{gse}/suppl/"
+        link_objects = html.fromstring(requests.get(url).content).xpath("//a")
+        links = [i.attrib["href"] for i in link_objects]
+
+        # Check if returned results are a valid page - a link to the 
+        # home page only exists where the GSE ID dow not exist
+        if "/" in links:
+            raise KeyError(f"The provided GEO ID {gse} does not exist.")
+
+        # The list of links for a valid GSE ID also contains a link to 
+        # the parent directory - we do not want that
+        links = [i for i in links if "geo/series/" not in i]
+
+        # The links are relative, we need absolute links to download
+        links = [i for i in links]
+
+        return links, url
+
+    def download(
+        self,
+        links=None,
+        root_url=None,
+        gse=None,
+        out_dir=None
+    ):
+        """Download GEO files.
+
+        Parameters
+        ----------
+        links: list
+               List of all links valid downloadable present for a GEO ID
+        out_dir: string
+                 Directory location for download
+        """
+        if out_dir is None:
+            out_dir = os.path.join(os.getcwd(), "pysradb_downloads")
+
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+        
+        # Display files to be downloaded
+        print("\nThe following files will be downloaded, if not already present: \n")
+        for link in links:
+            print(link)
+
+        # Check if we can access list of files in the tar file
+        tar_list = [i for i in links if ".tar" in i]
+        if "filelist.txt" in links:
+            tar_file = tar_list[0]
+            print(f"\nThe tar file {tar_file} contains the following files:\n")
+            file_list_contents = requests.get(root_url+"filelist.txt").content.decode("utf-8")
+            print(file_list_contents)
+
+        # Download files
+        for link in links:
+            # add a prefix to distinguish filelist.txt from different downloads
+            prefix = ""
+            if link == "filelist.txt":
+                prefix = gse+"_"
+            geo_path = os.path.join(out_dir, prefix+link)
+            download_file(root_url.lstrip("https://")+link, geo_path, show_progress=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.6.3
 pandas==1.2.4
 requests==2.25.1
 requests-ftp==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.2.3
+pandas==1.2.4
 requests==2.25.1
 requests-ftp==0.3.1
 tqdm==4.60.0

--- a/tests/test_geoweb.py
+++ b/tests/test_geoweb.py
@@ -8,21 +8,25 @@ import pytest
 
 from pysradb.geoweb import GEOweb
 
+
 @pytest.fixture(scope="module")
 def geoweb_connection():
     db = GEOweb()
     time.sleep(2)
     return db
 
+
 def test_valid_download_links(geoweb_connection):
     """Test if all links for a project are scraped"""
     links, url = geoweb_connection.get_download_links("GSE161707")
     assert links == ["GSE161707_RAW.tar", "filelist.txt"]
 
+
 def test_invalid_download_links(geoweb_connection):
     """Test if invalid GEO ID raises the expected error"""
     with pytest.raises(KeyError):
         links, url = geoweb_connection.get_download_links("GSE161709")
+
 
 def test_file_download(geoweb_connection):
     """Test if file actually gets downloaded"""
@@ -30,7 +34,7 @@ def test_file_download(geoweb_connection):
         links=["GSE161707_RAW.tar", "filelist.txt"],
         root_url="https://ftp.ncbi.nlm.nih.gov/geo/series/GSE161nnn/GSE161707/suppl/",
         gse="GSE161707",
-        out_dir="geoweb_downloads"
-        )
+        out_dir="geoweb_downloads",
+    )
     assert os.path.getsize("geoweb_downloads/GSE161707_RAW.tar")
     assert os.path.getsize("geoweb_downloads/GSE161707_filelist.txt")

--- a/tests/test_geoweb.py
+++ b/tests/test_geoweb.py
@@ -36,5 +36,5 @@ def test_file_download(geoweb_connection):
         gse="GSE161707",
         out_dir="geoweb_downloads",
     )
-    assert os.path.getsize("geoweb_downloads/GSE161707_RAW.tar")
-    assert os.path.getsize("geoweb_downloads/GSE161707_filelist.txt")
+    assert os.path.getsize("geoweb_downloads/GSE161707/GSE161707_RAW.tar")
+    assert os.path.getsize("geoweb_downloads/GSE161707/GSE161707_filelist.txt")

--- a/tests/test_geoweb.py
+++ b/tests/test_geoweb.py
@@ -1,0 +1,36 @@
+"""Tests for GEOweb"""
+
+import os
+import time
+
+import pandas as pd
+import pytest
+
+from pysradb.geoweb import GEOweb
+
+@pytest.fixture(scope="module")
+def geoweb_connection():
+    db = GEOweb()
+    time.sleep(2)
+    return db
+
+def test_valid_download_links(geoweb_connection):
+    """Test if all links for a project are scraped"""
+    links, url = geoweb_connection.get_download_links("GSE161707")
+    assert links == ["GSE161707_RAW.tar", "filelist.txt"]
+
+def test_invalid_download_links(geoweb_connection):
+    """Test if invalid GEO ID raises the expected error"""
+    with pytest.raises(KeyError):
+        links, url = geoweb_connection.get_download_links("GSE161709")
+
+def test_file_download(geoweb_connection):
+    """Test if file actually gets downloaded"""
+    geoweb_connection.download(
+        links=["GSE161707_RAW.tar", "filelist.txt"],
+        root_url="https://ftp.ncbi.nlm.nih.gov/geo/series/GSE161nnn/GSE161707/suppl/",
+        gse="GSE161707",
+        out_dir="geoweb_downloads"
+        )
+    assert os.path.getsize("geoweb_downloads/GSE161707_RAW.tar")
+    assert os.path.getsize("geoweb_downloads/GSE161707_filelist.txt")


### PR DESCRIPTION
Fixes Issue #120.

The `-g` argument allows downloads of GEO files. This argument can also be used concurrently with `-p`. The commands shown below are some valid uses of the argument:

```
# download GEO files for GEO ID GSE161707
pysradb -g GSE161707

# download GEO files for GEO IDs GSE161707 and GSE161708
pysradb -g GSE161707 GSE161708

# download GEO files for GEO ID GSE161707 and SRA files for SRP ID SRP016501
pysradb -g GSE161707 -p SRP016501
```
