### PR TITLE
Ena bug

### DIFF
--- a/pysradb/search.py
+++ b/pysradb/search.py
@@ -1276,18 +1276,19 @@ class EnaSearch(QuerySearch):
     def _format_query_string(self):
         term = ""
         if self.fields["query"]:
-            term += rf'experiment_title="*{self.fields["query"]}*" OR '
+            term += rf'(experiment_title="*{self.fields["query"]}*"'
             if not self.fields["accession"]:
                 self.fields["query"] = self.fields["query"].upper()
                 term += (
-                    rf'(study_accession="{self.fields["query"]}" OR '
+                    rf' OR study_accession="{self.fields["query"]}" OR '
                     rf'secondary_study_accession="{self.fields["query"]}" OR '
                     rf'sample_accession="{self.fields["query"]}" OR '
                     rf'secondary_sample_accession="{self.fields["query"]}" OR '
                     rf'experiment_accession="{self.fields["query"]}" OR '
                     rf'submission_accession="{self.fields["query"]}" OR '
-                    rf'run_accession="{self.fields["query"]}") AND '
+                    rf'run_accession="{self.fields["query"]}"'
                 )
+            term += ") AND "
         if self.fields["accession"]:
             self.fields["accession"] = self.fields["accession"].upper()
             term += (
@@ -1326,13 +1327,13 @@ class EnaSearch(QuerySearch):
                     f"Expected format: dd-mm-yyyy or dd-mm-yyyy:dd-mm-yyyy"
                 )
         if self.fields["platform"]:
-            term += rf'instrument_platform="{self.fields["platform"].upper()}" AND '
+            term += rf'instrument_platform="{self.fields["platform"]}" AND '
         if self.fields["selection"]:
-            term += rf'library_selection="{self.fields["selection"].upper()}" AND '
+            term += rf'library_selection="{self.fields["selection"]}" AND '
         if self.fields["source"]:
-            term += rf'library_source="{self.fields["source"].upper()}" AND '
+            term += rf'library_source="{self.fields["source"]}" AND '
         if self.fields["strategy"]:
-            term += rf'library_strategy="{self.fields["strategy"].upper()}" AND '
+            term += rf'library_strategy="{self.fields["strategy"]}" AND '
         if self.fields["title"]:
             term += rf'experiment_title="*{self.fields["title"]}*" AND '
         return term[:-5]  # Removing trailing " AND "

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1072,10 +1072,10 @@ def test_ena_search_3(capsys):
 
 def test_valid_search_query_1_ena(valid_search_inputs_1):
     expected_query = [
-        'experiment_title="*covid-19*" OR (study_accession="COVID-19" OR secondary_study_accession="COVID-19" OR'
+        '(experiment_title="*covid-19*" OR study_accession="COVID-19" OR secondary_study_accession="COVID-19" OR'
         ' sample_accession="COVID-19" OR secondary_sample_accession="COVID-19" OR experiment_accession="COVID-19" OR'
         ' submission_accession="COVID-19" OR run_accession="COVID-19")',
-        'experiment_title="*covid-19*" OR (study_accession="COVID-19" OR secondary_study_accession="COVID-19" OR'
+        '(experiment_title="*covid-19*" OR study_accession="COVID-19" OR secondary_study_accession="COVID-19" OR'
         ' sample_accession="COVID-19" OR secondary_sample_accession="COVID-19" OR experiment_accession="COVID-19" OR'
         ' submission_accession="COVID-19" OR run_accession="COVID-19")',
         '(study_accession="SRS6898940" OR secondary_study_accession="SRS6898940" OR sample_accession="SRS6898940" OR'
@@ -1101,22 +1101,22 @@ def test_valid_search_query_1_ena(valid_search_inputs_1):
 def test_valid_search_query_2_ena(valid_search_inputs_2):
     expected_query = [
         'library_layout="TRIPLE"',
-        'experiment_title="*Escherichia coli*" OR (study_accession="SRS6898222" OR '
+        '(experiment_title="*Escherichia coli*") AND (study_accession="SRS6898222" OR '
         'secondary_study_accession="SRS6898222" OR sample_accession="SRS6898222" OR '
         'secondary_sample_accession="SRS6898222" OR experiment_accession="SRS6898222" OR '
         'submission_accession="SRS6898222" OR run_accession="SRS6898222") AND tax_eq(562) AND library_layout="PAIRED" '
         "AND base_count>=5500000 AND base_count<6500000 AND first_created>=1999-01-01 AND "
-        'first_created<=2019-12-31 AND instrument_platform="ILLUMINA" AND library_selection="DNASE" AND '
-        'library_source="METATRANSCRIPTOMIC" AND library_strategy="MBD-SEQ"',
+        'first_created<=2019-12-31 AND instrument_platform="ILLUMINA" AND library_selection="DNase" AND '
+        'library_source="METATRANSCRIPTOMIC" AND library_strategy="MBD-Seq"',
         'library_layout="SINGLE" AND base_count>=4500000 AND base_count<5500000 AND first_created=2019-12-31 AND '
-        'instrument_platform="OXFORD_NANOPORE" AND library_selection="MBD2 PROTEIN METHYL-CPG BINDING DOMAIN" AND '
+        'instrument_platform="OXFORD_NANOPORE" AND library_selection="MBD2 protein methyl-CpG binding domain" AND '
         'library_source="GENOMIC SINGLE CELL" AND library_strategy="AMPLICON"',
-        'library_layout="PAIRED" AND instrument_platform="COMPLETE_GENOMICS" AND library_selection="INVERSE RRNA" AND '
-        'library_source="TRANSCRIPTOMIC" AND library_strategy="HI-C"',
-        'library_layout="SINGLE" AND instrument_platform="LS454" AND library_selection="OLIGO-DT" AND '
-        'library_source="TRANSCRIPTOMIC SINGLE CELL" AND library_strategy="MIRNA-SEQ"',
-        'instrument_platform="PACBIO_SMRT" AND library_selection="CDNA_OLIGO_DT.*" AND '
-        'library_source="METAGENOMIC" AND library_strategy="MBD-SEQ"',
+        'library_layout="PAIRED" AND instrument_platform="COMPLETE_GENOMICS" AND library_selection="Inverse rRNA" AND '
+        'library_source="TRANSCRIPTOMIC" AND library_strategy="Hi-C"',
+        'library_layout="SINGLE" AND instrument_platform="LS454" AND library_selection="Oligo-dT" AND '
+        'library_source="TRANSCRIPTOMIC SINGLE CELL" AND library_strategy="miRNA-Seq"',
+        'instrument_platform="PACBIO_SMRT" AND library_selection="cDNA_oligo_dT.*" AND '
+        'library_source="METAGENOMIC" AND library_strategy="MBD-Seq"',
         'instrument_platform="PACBIO_SMRT" AND library_selection="PCR" AND library_source="OTHER" AND '
         'library_strategy="EST"',
     ]
@@ -1130,7 +1130,7 @@ def test_valid_search_query_2_ena(valid_search_inputs_2):
 
 def test_ena_search_format_request():
     query_string = (
-        'experiment_title="*covid-19*" OR (study_accession="COVID-19" OR '
+        '(experiment_title="*covid-19*" OR study_accession="COVID-19" OR '
         'secondary_study_accession="COVID-19" OR sample_accession="COVID-19" OR '
         'secondary_sample_accession="COVID-19" OR experiment_accession="COVID-19" OR '
         'submission_accession="COVID-19" OR run_accession="COVID-19")'


### PR DESCRIPTION
#142 was due to ENA now enforcing case sensitivity on certain fields such as library_strategy. I had previously converted all queries to uppercase (eg RNA-seq was converted to RNA-SEQ instead of RNA-Seq), resulting in the bug. This should be fixed now. 
#143 was due to a misplaced parenthesis on my part. My apologies. 
Small update to test cases in test_search.py to account for the changes. 