### PR TITLE
fix xmltodict parse

### DIFF
--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -139,7 +139,12 @@ class SRAweb(SRAdb):
                   Parsed xml as dict
         """
         try:
-            json = xmltodict.parse(xml, process_namespaces=True)["root"]
+            xmldict = xmltodict.parse(
+                xml,
+                process_namespaces=True,
+                dict_constructor=OrderedDict
+            )
+            json = xmldict["root"]
         except ExpatError:
             raise RuntimeError("Unable to parse xml: {}".format(xml))
         return json
@@ -377,7 +382,7 @@ class SRAweb(SRAdb):
                 except:
                     request_json = {}  # eval(request_text)
             try:
-                xml_response = xmltodict.parse(request_text)
+                xml_response = xmltodict.parse(request_text, dict_constructor=OrderedDict)
 
                 exp_response = xml_response.get("EXPERIMENT_PACKAGE_SET", {})
                 response = exp_response.get("EXPERIMENT_PACKAGE", {})


### PR DESCRIPTION
Description:
xmltodict 0.13.0 dropped OrderedDict as the default dict constructor for python>=3.7: https://github.com/martinblech/xmltodict/compare/v0.12.0...v0.13.0. python3.7 dicts are by specification, ordered. This breaks line 453 of sraweb.py, which tests isinstance of OrderedDict. To fix this, we can pass an explicit argument `dict_constructor=OrderedDict` to `xmltodict.parse`.

Error reproduction (without the fix)
```
python -m venv venv
pip install numpy Cython pysradb
pysradb gsm-to-srr GSM2177186
# Error Message:
# UnboundLocalError: local variable 'exp_platform_model' referenced before assignment
```

Env:
python 3.7.6 (or python 3.8.10)

Other discussions:
The way xmltodict breaks backward compatibility and the way we specify 'xmltodict>=0.12.0' both contributed to this unexpected error. We may want to fix the minor version of xmltodict and only allow auto-upgrade of patch version: e.g. 'xmltodict~=0.13.0'.
Of course, the other way to fix this is to drop OrderedDict in pysradb for ordinary dict. More lines would be involved. I would opt to do that in a refactor PR.