### PR TITLE
Fix SRX -> SRR conversion

### DIFF
--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -531,7 +531,7 @@ class SRAweb(SRAdb):
                 experiment_record["run_total_spots"] = run_total_spots
                 experiment_record["run_total_bases"] = run_total_bases
 
-                sra_record.append(experiment_record)
+                sra_record.append(experiment_record.copy())
 
         # TODO: the detailed call below does redundant operations
         # the code above this can be completeley done away with
@@ -853,11 +853,15 @@ class SRAweb(SRAdb):
             set(srr_df.columns.tolist()).difference(gsm_df.columns.tolist())
         ) + ["experiment_accession"]
         joined_df = gsm_df.merge(srr_df[srr_cols], on="experiment_accession")
+        # ensure that only the requested SRR is returned
+        joined_df = joined_df[joined_df["run_accession"] == srr]
         return _order_first(joined_df, ["run_accession", "experiment_alias"])
 
     def srr_to_srp(self, srr, **kwargs):
         """Get SRP for a SRR"""
         srr_df = self.sra_metadata(srr, **kwargs)
+        # ensure that only the requested SRR is returned
+        srr_df = srr_df[srr_df["run_accession"] == srr]
         if kwargs and kwargs["detailed"] == True:
             return srr_df
         return _order_first(srr_df, ["run_accession", "study_accession"])
@@ -865,11 +869,15 @@ class SRAweb(SRAdb):
     def srr_to_srs(self, srr, **kwargs):
         """Get SRS for a SRR"""
         srr_df = self.sra_metadata(srr, **kwargs)
+        # ensure that only the requested SRR is returned
+        srr_df = srr_df[srr_df["run_accession"] == srr]
         return _order_first(srr_df, ["run_accession", "sample_accession"])
 
     def srr_to_srx(self, srr, **kwargs):
         """Get SRX for a SRR"""
         srr_df = self.sra_metadata(srr)
+        # ensure that only the requested SRR is returned
+        srr_df = srr_df[srr_df["run_accession"] == srr]
         return _order_first(srr_df, ["run_accession", "experiment_accession"])
 
     def srs_to_gsm(self, srs, **kwargs):
@@ -878,6 +886,8 @@ class SRAweb(SRAdb):
         time.sleep(self.sleep_time)
         gsm_df = self.srx_to_gsm(srx_df.experiment_accession.tolist(), **kwargs)
         srs_df = srx_df.merge(gsm_df, on="experiment_accession")
+        # ensure that only the requested SRS is returned
+        srs_df = srs_df[srs_df["sample_accession"] == srs]
         return _order_first(srs_df, ["sample_accession", "experiment_alias"])
 
     def srx_to_gsm(self, srx, **kwargs):

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -189,7 +189,7 @@ def test_srr_to_srx(sraweb_connection):
 def test_srs_to_gsm(sraweb_connection):
     """Test if srs is converted to gsm correctly"""
     df = sraweb_connection.srs_to_gsm("SRS079386")
-    assert list(df["experiment_alias"]) == ["GSM546921"]*3
+    assert list(df["experiment_alias"]) == ["GSM546921"] * 3
 
 
 def test_srs_to_srx(sraweb_connection):

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -189,8 +189,7 @@ def test_srr_to_srx(sraweb_connection):
 def test_srs_to_gsm(sraweb_connection):
     """Test if srs is converted to gsm correctly"""
     df = sraweb_connection.srs_to_gsm("SRS079386")
-    # there are two SRRs so just match first one
-    assert list(df["experiment_alias"])[0] == "GSM546921"
+    assert list(df["experiment_alias"]) == ["GSM546921"]*3
 
 
 def test_srs_to_srx(sraweb_connection):

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -216,6 +216,12 @@ def test_srx_to_srr(sraweb_connection):
     assert list(df["run_accession"]) == ["SRR5413172"]
 
 
+def test_srx_to_srr1(sraweb_connection):
+    """Test if srx is converted to srr correctly, including multiple srrs"""
+    df = sraweb_connection.srx_to_srr("SRX8998846")
+    assert list(df["run_accession"]) == ["SRR12508064", "SRR12508065"]
+
+
 def test_srx_to_srs(sraweb_connection):
     """Test if srx is converted to srs correctly"""
     df = sraweb_connection.srx_to_srs("SRX663253")

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -189,7 +189,8 @@ def test_srr_to_srx(sraweb_connection):
 def test_srs_to_gsm(sraweb_connection):
     """Test if srs is converted to gsm correctly"""
     df = sraweb_connection.srs_to_gsm("SRS079386")
-    assert list(df["experiment_alias"]) == ["GSM546921"]
+    # there are two SRRs so just match first one
+    assert list(df["experiment_alias"])[0] == "GSM546921"
 
 
 def test_srs_to_srx(sraweb_connection):


### PR DESCRIPTION
This fixes #182. The problem was that the same dictionary was modified and referenced by each element of the list.
Also fixes 4 test errors where the srr_to or srs_to function would return a df with other accessions in addition to the requested one.