### PR TITLE
Fix GeoSearch elink using retmode xml

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,5 +39,5 @@ jobs:
         codecov
     - uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "pip install -r requirements.txt && pip install . && pip install sphinx myst-parser && pip install sphinxcontrib-gtagjs ipython numpydoc sphinx-tabs sphinx_rtd_theme nbsphinx ipython pydata-sphinx-theme nbsphinx-link sphinx-panels"
+        pre-build-command: "pip install -r requirements.txt && pip install . && pip install -U sphinx myst-parser && pip install sphinxcontrib-gtagjs ipython numpydoc sphinx-tabs sphinx_rtd_theme nbsphinx ipython pydata-sphinx-theme nbsphinx-link sphinx-panels"
         docs-folder: "docs/"

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ venv.bak/
 .mypy_cache/
 *.sqlite
 *.sqlite.gz
+
+geoweb_downloads/

--- a/pysradb/search.py
+++ b/pysradb/search.py
@@ -1693,7 +1693,8 @@ class GeoSearch(SraSearch):
                 try:
                     root = Et.fromstring(r.text)
                     uids_from_geo = [
-                        elem.text for elem in root.findall(".//LinkSet/LinkSetDb/Link/Id")
+                        elem.text
+                        for elem in root.findall(".//LinkSet/LinkSetDb/Link/Id")
                     ]
                 except (Et.ParseError, TypeError, ValueError):
                     uids_from_geo = []

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1179,8 +1179,10 @@ def test_geo_search_1():
     instance = GeoSearch(3, 1000, geo_query="human")
     instance.search()
     df = instance.get_df()
-    df = instance.get_df()["experiment_accession"].to_list()
-    assert len(df) > 10
+    assert not df.empty
+    
+    experiment_accessions = instance.get_df()["experiment_accession"].to_list()
+    assert len(experiment_accessions) > 10
     # with open("./tests/data/test_search/geo_search_test1.txt", "r") as f:
     #    expected_accessions = f.read().splitlines()
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1180,7 +1180,7 @@ def test_geo_search_1():
     instance.search()
     df = instance.get_df()
     assert not df.empty
-    
+
     experiment_accessions = instance.get_df()["experiment_accession"].to_list()
     assert len(experiment_accessions) > 10
     # with open("./tests/data/test_search/geo_search_test1.txt", "r") as f:


### PR DESCRIPTION
`test_geo_search_1` was failing on all branches. The [eLink request](https://github.com/saketkc/pysradb/blob/50994f421583987a4e4bd380bda4e4bb27f350f3/pysradb/search.py#L1679-L1696) within `GeoSearch.search()` seemed to return an empty body despite receiving status code 200 and healthy response headers. Changing `'retmode': 'xml'` seems to generate the desired output.

The test seems to take a long time to run. I tested the code I changed to make sure it wasn't the cause. I'm not sure whether this performance differs from calls made in the past.

It may be worth reaching out to NCBI to understand why `the request with 'retmode': 'json'` stopped working.

This should unblock #198 #199 and any future PRs