### PR TITLE
Add gse-to-pmid; Fix for GSE with multiple SRPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ guide](https://www.saket-choudhary.me/pysradb/quickstart.html).
 
     $ pysradb
      usage: pysradb [-h] [--version] [--citation]
-                    {metadata,download,search,gse-to-gsm,gse-to-srp,gsm-to-gse,gsm-to-srp,gsm-to-srr,gsm-to-srs,gsm-to-srx,srp-to-gse,srp-to-srr,srp-to-srs,srp-to-srx,srr-to-gsm,srr-to-srp,srr-to-srs,srr-to-srx,srs-to-gsm,srs-to-srx,srx-to-srp,srx-to-srr,srx-to-srs,sra-to-pmid}
+                    {metadata,download,search,gse-to-gsm,gse-to-srp,gsm-to-gse,gsm-to-srp,gsm-to-srr,gsm-to-srs,gsm-to-srx,srp-to-gse,srp-to-srr,srp-to-srs,srp-to-srx,srr-to-gsm,srr-to-srp,srr-to-srs,srr-to-srx,srs-to-gsm,srs-to-srx,srx-to-srp,srx-to-srr,srx-to-srs,srp-to-pmid,gse-to-pmid}
                     ...
 
      pysradb: Query NGS metadata and data from NCBI Sequence Read Archive.
@@ -34,7 +34,7 @@ guide](https://www.saket-choudhary.me/pysradb/quickstart.html).
        --citation            how to cite
 
      subcommands:
-       {metadata,download,search,gse-to-gsm,gse-to-srp,gsm-to-gse,gsm-to-srp,gsm-to-srr,gsm-to-srs,gsm-to-srx,srp-to-gse,srp-to-srr,srp-to-srs,srp-to-srx,srr-to-gsm,srr-to-srp,srr-to-srs,srr-to-srx,srs-to-gsm,srs-to-srx,srx-to-srp,srx-to-srr,srx-to-srs,sra-to-pmid}
+       {metadata,download,search,gse-to-gsm,gse-to-srp,gsm-to-gse,gsm-to-srp,gsm-to-srr,gsm-to-srs,gsm-to-srx,srp-to-gse,srp-to-srr,srp-to-srs,srp-to-srx,srr-to-gsm,srr-to-srp,srr-to-srs,srr-to-srx,srs-to-gsm,srs-to-srx,srx-to-srp,srx-to-srr,srx-to-srs,srp-to-pmid,gse-to-pmid}
          metadata            Fetch metadata for SRA project (SRPnnnn)
          download            Download SRA project (SRPnnnn)
          search              Search SRA/ENA for matching text
@@ -58,7 +58,8 @@ guide](https://www.saket-choudhary.me/pysradb/quickstart.html).
          srx-to-srp          Get SRP for a SRX
          srx-to-srr          Get SRR for a SRX
          srx-to-srs          Get SRS for a SRX
-         sra-to-pmid         Get PMIDs for SRA accessions
+         srp-to-pmid         Get PMIDs for SRP accessions
+        gse-to-pmid         Get PMIDs for GSE accessions
 
 ## Quickstart
 
@@ -193,12 +194,19 @@ conda create -c bioconda -n pysradb PYTHON=3.10 pysradb
     experiment_alias run_accession
     GSM2177186       SRR3587529
 
-### Converting SRA to PMID
+### Converting SRP to PMID
 
-    $ pysradb sra-to-pmid SRR3587529
+    $ pysradb srp-to-pmid SRP045778
 
-    sra_accession pmid
-    SRR3587529    27373336
+    srp_accession bioproject pmid
+    SRP045778     PRJNA257197 27373336
+
+### Converting GSE to PMID
+
+    $ pysradb gse-to-pmid GSE253406
+
+    gse_accession pmid
+    GSE253406     39528918
 
 ### Downloading supplementary files from GEO
 

--- a/pysradb/cli.py
+++ b/pysradb/cli.py
@@ -523,9 +523,24 @@ def srx_to_srs(srx_ids, saveto, detailed, desc, expand):
     sradb.close()
 
 
+def srp_to_pmid(srp_ids, saveto):
+    sradb = SRAweb()
+    df = sradb.srp_to_pmid(srp_ids)
+    _print_save_df(df, saveto)
+    sradb.close()
+
+
 def sra_to_pmid(sra_ids, saveto):
+    """Backward compatibility wrapper for sra_to_pmid"""
     sradb = SRAweb()
     df = sradb.sra_to_pmid(sra_ids)
+    _print_save_df(df, saveto)
+    sradb.close()
+
+
+def gse_to_pmid(gse_ids, saveto):
+    sradb = SRAweb()
+    df = sradb.gse_to_pmid(gse_ids)
     _print_save_df(df, saveto)
     sradb.close()
 
@@ -1170,15 +1185,21 @@ def parse_args(args=None):
     subparser.add_argument("srx_ids", nargs="+")
     subparser.set_defaults(func=srx_to_srs)
 
-    # pysradb sra-to-pmid
+    # pysradb srp-to-pmid
     subparser = subparsers.add_parser(
-        "sra-to-pmid", help="Get PMIDs for SRA accessions"
+        "srp-to-pmid", help="Get PMIDs for SRP accessions"
     )
     subparser.add_argument("--saveto", help="Save output to file")
-    subparser.add_argument(
-        "sra_ids", nargs="+", help="SRA accession(s) - can be SRP, SRR, SRX, or SRS"
+    subparser.add_argument("srp_ids", nargs="+", help="SRP accession(s)")
+    subparser.set_defaults(func=srp_to_pmid)
+
+    # pysradb gse-to-pmid
+    subparser = subparsers.add_parser(
+        "gse-to-pmid", help="Get PMIDs for GSE accessions"
     )
-    subparser.set_defaults(func=sra_to_pmid)
+    subparser.add_argument("--saveto", help="Save output to file")
+    subparser.add_argument("gse_ids", nargs="+", help="GSE accession(s)")
+    subparser.set_defaults(func=gse_to_pmid)
 
     args = parser.parse_args(args=None if sys.argv[1:] else ["--help"])
     if args.command == "metadata":
@@ -1253,8 +1274,10 @@ def parse_args(args=None):
         srx_to_srr(args.srx_ids, args.saveto, args.detailed, args.desc, args.expand)
     elif args.command == "srx-to-srs":
         srx_to_srs(args.srx_ids, args.saveto, args.detailed, args.desc, args.expand)
-    elif args.command == "sra-to-pmid":
-        sra_to_pmid(args.sra_ids, args.saveto)
+    elif args.command == "srp-to-pmid":
+        srp_to_pmid(args.srp_ids, args.saveto)
+    elif args.command == "gse-to-pmid":
+        gse_to_pmid(args.gse_ids, args.saveto)
 
 
 if __name__ == "__main__":

--- a/pysradb/sraweb.py
+++ b/pysradb/sraweb.py
@@ -441,7 +441,6 @@ class SRAweb(SRAdb):
         try:
             uids = esummary_result["uids"]
         except KeyError:
-            print("No results found for {}".format(srp))
             return None
 
         exps_xml = OrderedDict()
@@ -843,7 +842,13 @@ class SRAweb(SRAdb):
     def gse_to_srp(self, gse, **kwargs):
         if isinstance(gse, str):
             gse = [gse]
+        if not gse:  # Handle empty input
+            return pd.DataFrame(columns=["study_alias", "study_accession"])
+
         gse_df = self.fetch_gds_results(gse, **kwargs)
+        if gse_df is None or gse_df.empty:  # Handle case where no results found
+            return pd.DataFrame(columns=["study_alias", "study_accession"])
+
         gse_df = gse_df.rename(
             columns={"accession": "study_alias", "SRA": "study_accession"}
         )
@@ -867,9 +872,20 @@ class SRAweb(SRAdb):
                     gse_df_subset_gse.study_accession.tolist()
                 )
             )
-            new_gse_df = pd.DataFrame(
-                {"study_alias": gse_of_interest, "study_accession": srp_unique}
-            )
+            # Handle mismatched lengths between GSEs and SRPs
+            # Create all combinations of GSE-SRP pairs
+            gse_srp_pairs = []
+            for gse_id in gse_of_interest:
+                for srp_id in srp_unique:
+                    gse_srp_pairs.append(
+                        {"study_alias": gse_id, "study_accession": srp_id}
+                    )
+
+            if gse_srp_pairs:
+                new_gse_df = pd.DataFrame(gse_srp_pairs)
+            else:
+                # If no pairs, create empty DataFrame with correct columns
+                new_gse_df = pd.DataFrame(columns=["study_alias", "study_accession"])
             gse_df_subset = pd.concat([gse_df_subset_gse, new_gse_df])
         gse_df_subset = gse_df_subset.loc[gse_df_subset.study_alias.isin(gse)]
         return gse_df_subset[["study_alias", "study_accession"]].drop_duplicates()
@@ -923,12 +939,49 @@ class SRAweb(SRAdb):
         return gsm_df[["experiment_alias", "experiment_accession"]].drop_duplicates()
 
     def gsm_to_gse(self, gsm, **kwargs):
+        if isinstance(gsm, str):
+            gsm = [gsm]
+        if not gsm:  # Handle empty input
+            return pd.DataFrame(columns=["study_alias", "study_accession"])
+
         gsm_df = self.fetch_gds_results(gsm, **kwargs)
-        gsm_df = gsm_df[gsm_df.entrytype == "GSE"]
-        gsm_df = gsm_df.rename(
-            columns={"accession": "study_alias", "SRA": "study_accession"}
-        )
-        return gsm_df[["study_alias", "study_accession"]]
+        if gsm_df is None or gsm_df.empty:  # Handle case where no results found
+            return pd.DataFrame(columns=["study_alias", "study_accession"])
+
+        # For GSM queries, we need to extract GSE IDs from the 'gse' column
+        # The entrytype will be 'GSM', not 'GSE'
+        gsm_entries = gsm_df[gsm_df.entrytype == "GSM"]
+
+        if gsm_entries.empty:
+            return pd.DataFrame(columns=["study_alias", "study_accession"])
+
+        # Extract GSE IDs from the 'gse' column and create result rows
+        results = []
+        for _, row in gsm_entries.iterrows():
+            gsm_id = row["accession"]
+            gse_str = str(row.get("gse", ""))
+
+            if gse_str and gse_str != "nan":
+                # Handle multiple GSE IDs separated by semicolon
+                gse_ids = [
+                    gse_id.strip() for gse_id in gse_str.split(";") if gse_id.strip()
+                ]
+                for gse_id in gse_ids:
+                    if gse_id.isdigit():
+                        # Add GSE prefix if it's just a number
+                        gse_id = f"GSE{gse_id}"
+                    results.append(
+                        {
+                            "study_alias": gse_id,
+                            "study_accession": row.get("SRA", pd.NA),
+                        }
+                    )
+
+        if results:
+            result_df = pd.DataFrame(results)
+            return result_df[["study_alias", "study_accession"]].drop_duplicates()
+        else:
+            return pd.DataFrame(columns=["study_alias", "study_accession"])
 
     def srp_to_gse(self, srp, **kwargs):
         """Get GSE for a SRP"""
@@ -1142,26 +1195,26 @@ class SRAweb(SRAdb):
 
         return bioproject_pmids
 
-    def sra_to_pmid(self, sra_accessions):
-        """Get PMIDs associated with SRA accessions
+    def srp_to_pmid(self, srp_accessions):
+        """Get PMIDs associated with SRP accessions
 
         Parameters
         ----------
-        sra_accessions: list or str
-                       SRA accession(s) - can be SRP, SRR, SRX, or SRS
+        srp_accessions: list or str
+                       SRP accession(s)
 
         Returns
         -------
-        sra_pmid_df: pandas.DataFrame
-                    DataFrame with SRA accessions and associated PMIDs
+        srp_pmid_df: pandas.DataFrame
+                    DataFrame with SRP accessions and associated PMIDs
         """
-        if isinstance(sra_accessions, str):
-            sra_accessions = [sra_accessions]
+        if isinstance(srp_accessions, str):
+            srp_accessions = [srp_accessions]
 
         # Get metadata to extract BioProject information
-        metadata_df = self.sra_metadata(sra_accessions)
+        metadata_df = self.sra_metadata(srp_accessions)
         if metadata_df is None or metadata_df.empty:
-            return pd.DataFrame(columns=["sra_accession", "bioproject", "pmid"])
+            return pd.DataFrame(columns=["srp_accession", "bioproject", "pmid"])
 
         # Try to get PMIDs via BioProject first
         unique_bioprojects = metadata_df["bioproject"].dropna().unique().tolist()
@@ -1170,12 +1223,12 @@ class SRAweb(SRAdb):
         # If no BioProject PMIDs found, try fallback search
         external_pmids = []
         if not any(pmids for pmids in bioproject_pmids.values()):
-            external_pmids = self._search_fallback_pmids(sra_accessions)
+            external_pmids = self._search_fallback_pmids(srp_accessions)
 
-        # Build results - one row per unique SRA accession
+        # Build results - one row per unique SRP accession
         results = []
         for _, row in metadata_df.iterrows():
-            sra_acc = self._extract_sra_accession(row)
+            srp_acc = self._extract_sra_accession(row)
             bioproject = row.get("bioproject", "")
 
             # Get PMIDs (BioProject takes priority over external)
@@ -1187,7 +1240,7 @@ class SRAweb(SRAdb):
             smallest_pmid = self._get_smallest_pmid(pmids) if pmids else pd.NA
             results.append(
                 {
-                    "sra_accession": sra_acc,
+                    "srp_accession": srp_acc,
                     "bioproject": bioproject,
                     "pmid": smallest_pmid,
                 }
@@ -1195,8 +1248,8 @@ class SRAweb(SRAdb):
 
         return pd.DataFrame(results).drop_duplicates()
 
-    def _search_fallback_pmids(self, sra_accessions):
-        """Search for PMIDs using fallback strategies (external sources + direct SRA search)"""
+    def _search_fallback_pmids(self, srp_accessions):
+        """Search for PMIDs using fallback strategies (external sources + direct SRA search + GSE search)"""
         try:
             original_sleep = self.sleep_time
             self.sleep_time = max(0.1, self.sleep_time * 0.5)
@@ -1204,22 +1257,30 @@ class SRAweb(SRAdb):
             # Strategy 1: Search via external source identifiers
             # Example: ERP018009
             detailed_metadata = self.sra_metadata(
-                sra_accessions, detailed=True, include_pmids=False
+                srp_accessions, detailed=True, include_pmids=False
             )
             if detailed_metadata is not None and not detailed_metadata.empty:
                 if external_sources := self.extract_external_sources(detailed_metadata):
                     pmids = self.search_pmc_for_external_sources([external_sources[0]])
                     if pmids:
                         return pmids
-            # Strategy 2: Direct SRA ID search
+
+                # Strategy 2: Search via GSE identifiers extracted from metadata
+                # Example: GSE253406 --> SRP484103
+                gse_pmids = self._search_gse_gsm_pmids(
+                    detailed_metadata, srp_accessions
+                )
+                if gse_pmids:
+                    return gse_pmids
+
+            # Strategy 3: Direct SRP ID search
             # Example: SRP047086
-            pmids = self.search_pmc_for_external_sources(sra_accessions)
+            pmids = self.search_pmc_for_external_sources(srp_accessions)
             return pmids
 
         except Exception as e:
             return []
         finally:
-            # Restore original sleep time
             self.sleep_time = original_sleep
 
     def _extract_sra_accession(self, row):
@@ -1262,7 +1323,6 @@ class SRAweb(SRAdb):
         """
         external_sources = []
 
-        # Common external database patterns
         patterns = [
             r"E-MTAB-\d+",  # ArrayExpress
             r"GSE\d+",  # GEO Series
@@ -1287,6 +1347,212 @@ class SRAweb(SRAdb):
 
         return external_sources
 
+    def _search_gse_gsm_pmids(self, metadata_df, sra_accessions):
+        """Search for PMIDs using GSE identifiers from BioProject and SRP conversion
+
+        Parameters
+        ----------
+        metadata_df: pandas.DataFrame
+                    Detailed metadata DataFrame
+        sra_accessions: list
+                       List of SRA accessions being searched
+
+        Returns
+        -------
+        pmids: list
+              List of PMIDs found via GSE search
+        """
+        import time
+
+        gse_identifiers = []
+
+        # Strategy 1: BioProject to GSE conversion via NCBI search
+        if "bioproject" in metadata_df.columns:
+            unique_bioprojects = metadata_df["bioproject"].dropna().unique()
+            for bioproject in unique_bioprojects[
+                :3
+            ]:  # Limit to avoid too many requests
+                try:
+                    gse_ids = self._bioproject_to_gse(bioproject)
+                    gse_identifiers.extend(gse_ids)
+                    time.sleep(self.sleep_time)  # Rate limiting
+                except Exception:
+                    pass
+
+        # Strategy 2: SRP to GSE conversion via NCBI ELink
+        for sra_acc in sra_accessions:
+            if sra_acc.startswith("SRP"):
+                try:
+                    gse_ids = self._srp_to_gse_via_elink(sra_acc)
+                    gse_identifiers.extend(gse_ids)
+                    time.sleep(self.sleep_time)  # Rate limiting
+                except Exception:
+                    pass
+
+        # Strategy 3: Try existing pysradb SRP to GSE conversion
+        for sra_acc in sra_accessions:
+            if sra_acc.startswith("SRP"):
+                try:
+                    gse_df = self.srp_to_gse(sra_acc)
+                    if not gse_df.empty and "experiment_alias" in gse_df.columns:
+                        gse_values = gse_df["experiment_alias"].dropna().astype(str)
+                        for gse_val in gse_values:
+                            if gse_val.startswith("GSE"):
+                                gse_identifiers.append(gse_val)
+                except Exception:
+                    pass
+
+        # Remove duplicates and search PMC for GSE identifiers
+        unique_gse_ids = list(set(gse_identifiers))
+
+        if unique_gse_ids:
+            pmids = self.search_pmc_for_external_sources(unique_gse_ids)
+            return pmids
+
+        return []
+
+    def _bioproject_to_gse(self, bioproject):
+        """Convert BioProject ID to GSE ID via NCBI search
+
+        Parameters
+        ----------
+        bioproject: str
+                   BioProject ID (e.g., 'PRJNA1065472')
+
+        Returns
+        -------
+        gse_ids: list
+                List of GSE IDs found
+        """
+        import requests
+
+        gse_ids = []
+        try:
+            search_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+            search_params = {
+                "db": "gds",
+                "term": f"{bioproject}[BioProject]",
+                "retmode": "json",
+                "retmax": "10",
+            }
+
+            response = requests.get(search_url, params=search_params, timeout=30)
+            response.raise_for_status()
+            result = response.json()
+            geo_uids = result["esearchresult"]["idlist"]
+
+            if geo_uids:
+                # Get summary to find GSE IDs
+                summary_url = (
+                    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+                )
+                summary_params = {
+                    "db": "gds",
+                    "id": ",".join(geo_uids),
+                    "retmode": "json",
+                }
+
+                summary_response = requests.get(
+                    summary_url, params=summary_params, timeout=30
+                )
+                summary_response.raise_for_status()
+                summary_result = summary_response.json()
+
+                for uid in geo_uids:
+                    if uid in summary_result["result"]:
+                        record = summary_result["result"][uid]
+                        accession = record.get("accession", "")
+                        if accession.startswith("GSE"):
+                            gse_ids.append(accession)
+
+        except Exception:
+            pass
+
+        return gse_ids
+
+    def _srp_to_gse_via_elink(self, srp_id):
+        """Convert SRP ID to GSE ID via NCBI ELink
+
+        Parameters
+        ----------
+        srp_id: str
+               SRP ID (e.g., 'SRP484103')
+
+        Returns
+        -------
+        gse_ids: list
+                List of GSE IDs found
+        """
+        import requests
+
+        gse_ids = []
+        try:
+            # First, search for the SRP in SRA database to get UIDs
+            search_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+            search_params = {
+                "db": "sra",
+                "term": srp_id,
+                "retmode": "json",
+                "retmax": "5",
+            }
+
+            response = requests.get(search_url, params=search_params, timeout=30)
+            response.raise_for_status()
+            result = response.json()
+            sra_uids = result["esearchresult"]["idlist"]
+
+            if sra_uids:
+                # Use ELink to find related GEO records
+                elink_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
+                elink_params = {
+                    "dbfrom": "sra",
+                    "db": "gds",
+                    "id": sra_uids[0],  # Use first UID
+                    "retmode": "json",
+                }
+
+                elink_response = requests.get(
+                    elink_url, params=elink_params, timeout=30
+                )
+                elink_response.raise_for_status()
+                elink_result = elink_response.json()
+
+                if "linksets" in elink_result:
+                    for linkset in elink_result["linksets"]:
+                        if "linksetdbs" in linkset:
+                            for linksetdb in linkset["linksetdbs"]:
+                                if linksetdb["dbto"] == "gds":
+                                    geo_uids = linksetdb["links"]
+
+                                    if geo_uids:
+                                        # Get summary to find GSE IDs
+                                        summary_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+                                        summary_params = {
+                                            "db": "gds",
+                                            "id": ",".join(geo_uids),
+                                            "retmode": "json",
+                                        }
+
+                                        summary_response = requests.get(
+                                            summary_url,
+                                            params=summary_params,
+                                            timeout=30,
+                                        )
+                                        summary_response.raise_for_status()
+                                        summary_result = summary_response.json()
+
+                                        for uid in geo_uids:
+                                            if uid in summary_result["result"]:
+                                                record = summary_result["result"][uid]
+                                                accession = record.get("accession", "")
+                                                if accession.startswith("GSE"):
+                                                    gse_ids.append(accession)
+
+        except Exception:
+            pass
+
+        return gse_ids
+
     def search_pmc_for_external_sources(self, external_sources):
         """Search PubMed Central for PMIDs using external source identifiers
 
@@ -1307,8 +1573,6 @@ class SRAweb(SRAdb):
 
         for source in external_sources:
             try:
-
-                # Search PMC for this external source
                 search_url = (
                     "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
                 )
@@ -1363,9 +1627,31 @@ class SRAweb(SRAdb):
 
         return list(set(all_pmids))  # Remove duplicates
 
-    def srp_to_pmid(self, srp):
-        """Get PMIDs for Study Accessions (SRP)"""
-        return self.sra_to_pmid(srp)
+    def sra_to_pmid(self, sra_accessions):
+        """Get PMIDs for SRA accessions (backward compatibility wrapper)
+
+        Parameters
+        ----------
+        sra_accessions: list or str
+                       SRA accession(s) - can be SRP, SRR, SRX, or SRS
+
+        Returns
+        -------
+        sra_pmid_df: pandas.DataFrame
+                    DataFrame with SRA accessions and associated PMIDs
+        """
+        # For SRP accessions, use the main method
+        if isinstance(sra_accessions, str):
+            if sra_accessions.startswith("SRP"):
+                return self.srp_to_pmid(sra_accessions)
+        elif isinstance(sra_accessions, list):
+            # If all are SRP accessions, use main method
+            if all(acc.startswith("SRP") for acc in sra_accessions):
+                return self.srp_to_pmid(sra_accessions)
+
+        # For other SRA accessions, convert to SRP first if possible
+        # This is a simplified implementation for backward compatibility
+        return self.srp_to_pmid(sra_accessions)
 
     def srr_to_pmid(self, srr):
         """Get PMIDs for Run Accessions (SRR)"""
@@ -1378,6 +1664,36 @@ class SRAweb(SRAdb):
     def srs_to_pmid(self, srs):
         """Get PMIDs for Sample Accessions (SRS)"""
         return self.sra_to_pmid(srs)
+
+    def gse_to_pmid(self, gse_accessions):
+        """Get PMIDs for GSE accessions by searching PubMed Central
+
+        Parameters
+        ----------
+        gse_accessions: list or str
+                       GSE accession(s)
+
+        Returns
+        -------
+        gse_pmid_df: pandas.DataFrame
+                    DataFrame with GSE accessions and associated PMIDs
+        """
+        if isinstance(gse_accessions, str):
+            gse_accessions = [gse_accessions]
+
+        results = []
+        for gse_acc in gse_accessions:
+            pmids = self.search_pmc_for_external_sources([gse_acc])
+            smallest_pmid = self._get_smallest_pmid(pmids) if pmids else pd.NA
+
+            results.append(
+                {
+                    "gse_accession": gse_acc,
+                    "pmid": smallest_pmid,
+                }
+            )
+
+        return pd.DataFrame(results)
 
     def close(self):
         # Dummy method to mimick SRAdb() object

--- a/tests/test_sraweb.py
+++ b/tests/test_sraweb.py
@@ -152,6 +152,30 @@ def test_gsm_to_gse(sraweb_connection):
     assert df["study_alias"].tolist()[0] == "GSE56924"
 
 
+def test_gsm_to_gse_multiple_gses(sraweb_connection):
+    """Test GSM that maps to multiple GSE accessions (GSM7430904 -> GSE233587, GSE234305)"""
+    df = sraweb_connection.gsm_to_gse("GSM7430904")
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert "study_alias" in df.columns
+    assert "study_accession" in df.columns
+
+    # Check that GSM7430904 maps to the expected GSEs
+    study_aliases = df["study_alias"].tolist()
+
+    # Should map to multiple GSEs
+    assert len(study_aliases) >= 2
+    # Check for the known GSE accessions
+    expected_gses = {"GSE233587", "GSE234305"}
+    actual_gses = set(study_aliases)
+    assert expected_gses.issubset(
+        actual_gses
+    ), f"Expected {expected_gses} to be subset of {actual_gses}"
+
+    # Verify that GSE234305 is specifically included (this was the original issue)
+    assert "GSE234305" in study_aliases
+
+
 def test_gsm_to_srr(sraweb_connection):
     """Test if gsm is converted to srr correctly"""
     df = sraweb_connection.gsm_to_srr("GSM1371489")
@@ -265,6 +289,29 @@ def test_gse_to_srp3(sraweb_connection):
     assert df["study_accession"].tolist()[0] == "SRP093251"
 
 
+def test_gse_to_srp_multiple_srps(sraweb_connection):
+    """Test GSE that maps to multiple SRP accessions (GSE234305 -> SRP411077, SRP439808)"""
+    df = sraweb_connection.gse_to_srp("GSE234305")
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert "study_alias" in df.columns
+    assert "study_accession" in df.columns
+
+    # Check that GSE234305 maps to the expected SRPs
+    study_aliases = df["study_alias"].tolist()
+    study_accessions = df["study_accession"].tolist()
+
+    assert "GSE234305" in study_aliases
+    # Should map to multiple SRPs
+    assert len(set(study_accessions)) >= 2
+    # Check for the known SRP accessions
+    expected_srps = {"SRP411077", "SRP439808"}
+    actual_srps = set(study_accessions)
+    assert expected_srps.issubset(
+        actual_srps
+    ), f"Expected {expected_srps} to be subset of {actual_srps}"
+
+
 def test_fetch_bioproject_pmids(sraweb_connection):
     """Test fetching PMIDs for BioProject accessions"""
     # Use a known BioProject that should have publications
@@ -287,18 +334,18 @@ def test_fetch_bioproject_pmids_multiple(sraweb_connection):
 
 
 def test_sra_to_pmid(sraweb_connection):
-    """Test SRA to PMID functionality"""
+    """Test SRA to PMID functionality (backward compatibility)"""
     df = sraweb_connection.sra_to_pmid("SRP002605")
     assert isinstance(df, pd.DataFrame)
-    required_columns = {"sra_accession", "bioproject", "pmid"}
+    required_columns = {"srp_accession", "bioproject", "pmid"}
     assert required_columns.issubset(set(df.columns))
 
 
 def test_srp_to_pmid(sraweb_connection):
-    """Test SRP to PMID convenience method"""
+    """Test SRP to PMID main method"""
     df = sraweb_connection.srp_to_pmid("SRP002605")
     assert isinstance(df, pd.DataFrame)
-    assert "sra_accession" in df.columns
+    assert "srp_accession" in df.columns
     assert "pmid" in df.columns
 
 
@@ -306,12 +353,39 @@ def test_srr_to_pmid(sraweb_connection):
     """Test SRR to PMID convenience method"""
     df = sraweb_connection.srr_to_pmid("SRR057511")
     assert isinstance(df, pd.DataFrame)
-    assert "sra_accession" in df.columns
+    assert "srp_accession" in df.columns
     assert "pmid" in df.columns
 
 
 def test_sra_to_pmid_multiple(sraweb_connection):
-    """Test SRA to PMID with multiple accessions"""
+    """Test SRA to PMID with multiple accessions (backward compatibility)"""
     df = sraweb_connection.sra_to_pmid(["SRP002605", "SRP016501"])
     assert isinstance(df, pd.DataFrame)
     assert len(df) >= 2  # Should have at least one row per input SRA
+
+
+def test_srp_to_pmid_multiple(sraweb_connection):
+    """Test SRP to PMID with multiple accessions"""
+    df = sraweb_connection.srp_to_pmid(["SRP002605", "SRP016501"])
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 2  # Should have at least one row per input SRP
+    assert "srp_accession" in df.columns
+    assert "pmid" in df.columns
+
+
+def test_gse_to_pmid(sraweb_connection):
+    """Test GSE to PMID functionality"""
+    df = sraweb_connection.gse_to_pmid("GSE253406")
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    required_columns = {"gse_accession", "pmid"}
+    assert required_columns.issubset(df.columns)
+
+
+def test_gse_to_pmid_multiple(sraweb_connection):
+    """Test GSE to PMID with multiple accessions"""
+    df = sraweb_connection.gse_to_pmid(["GSE253406", "GSE168776"])
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 2  # Should have one row per input GSE
+    assert "gse_accession" in df.columns
+    assert "pmid" in df.columns


### PR DESCRIPTION
## Summary by Sourcery

Add dedicated SRP/GSE to PMID functionality and improve conversion robustness between GSE, GSM, and SRP. Enhance fallback PMID search with exploratory GSE/GSM lookup methods, fix edge cases in conversion functions, and expand tests and CLI documentation accordingly.

New Features:
- Add CLI commands 'srp-to-pmid' and 'gse-to-pmid' for fetching PMIDs
- Implement gse_to_pmid method in SRAweb for retrieving PMIDs of GSE accessions
- Provide backward compatibility wrapper for sra_to_pmid

Bug Fixes:
- Fix gse_to_srp and gsm_to_gse to handle empty inputs, no-result cases, and multiple mappings between GSE, GSM, and SRP

Enhancements:
- Extend PMID fallback search to include GSE/GSM-based strategies with new helper methods (_search_gse_gsm_pmids, _bioproject_to_gse, _srp_to_gse_via_elink)

Documentation:
- Update README to include new 'srp-to-pmid' and 'gse-to-pmid' CLI subcommands and examples

Tests:
- Add tests for multiple mapping scenarios in gse_to_srp and gsm_to_gse
- Add tests for new srp_to_pmid, gse_to_pmid, and sra_to_pmid backward compatibility